### PR TITLE
Implemented Keep Alive

### DIFF
--- a/PushSharp.Apple/ApnsHttp2Connection.cs
+++ b/PushSharp.Apple/ApnsHttp2Connection.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using Newtonsoft.Json.Linq;
 using System.Net;
 using HttpTwo;
+using System.Threading;
+using PushSharp.Core;
 
 namespace PushSharp.Apple
 {
@@ -15,7 +17,7 @@ namespace PushSharp.Apple
     {
         static int ID = 0;
 
-        public ApnsHttp2Connection (ApnsHttp2Configuration configuration)
+        public ApnsHttp2Connection(ApnsHttp2Configuration configuration)
         {
             id = ++ID;
             if (id >= int.MaxValue)
@@ -24,35 +26,48 @@ namespace PushSharp.Apple
             Configuration = configuration;
 
             certificate = Configuration.Certificate;
+            currentKeepAlivePeriod = Configuration.KeepAlivePeriod;
 
-            certificates = new X509CertificateCollection ();
+            certificates = new X509CertificateCollection();
 
             // Add local/machine certificate stores to our collection if requested
-            if (Configuration.AddLocalAndMachineCertificateStores) {
-                var store = new X509Store (StoreLocation.LocalMachine);
-                certificates.AddRange (store.Certificates);
+            if (Configuration.AddLocalAndMachineCertificateStores)
+            {
+                var store = new X509Store(StoreLocation.LocalMachine);
+                certificates.AddRange(store.Certificates);
 
-                store = new X509Store (StoreLocation.CurrentUser);
-                certificates.AddRange (store.Certificates);
+                store = new X509Store(StoreLocation.CurrentUser);
+                certificates.AddRange(store.Certificates);
             }
 
             // Add optionally specified additional certs into our collection
-            if (Configuration.AdditionalCertificates != null) {
+            if (Configuration.AdditionalCertificates != null)
+            {
                 foreach (var addlCert in Configuration.AdditionalCertificates)
-                    certificates.Add (addlCert);
+                    certificates.Add(addlCert);
             }
 
             // Finally, add the main private cert for authenticating to our collection
             if (certificate != null)
-                certificates.Add (certificate);
+                certificates.Add(certificate);
 
-            var http2Settings = new HttpTwo.Http2ConnectionSettings (
+            var http2Settings = new HttpTwo.Http2ConnectionSettings(
                 Configuration.Host,
-               (uint)Configuration.Port, 
-                true, 
+               (uint)Configuration.Port,
+                true,
                 certificates);
-            
-            http2 = new HttpTwo.Http2Client (http2Settings);
+
+            http2 = new HttpTwo.Http2Client(http2Settings);
+
+            // Initialize timer to try and keep the connection alive
+            if (Configuration.KeepAlivePeriod != null && Configuration.TryKeepingConnectionAlive)
+            {
+                Log.Info("Initializing Kepp Alive Timer");
+
+                keepAliveStartTimeSpan = TimeSpan.FromSeconds(30);
+
+                keepAliveTimer = new Timer(e => Ping(), null, keepAliveStartTimeSpan, Configuration.KeepAlivePeriod);
+            }
         }
 
         public ApnsHttp2Configuration Configuration { get; private set; }
@@ -61,68 +76,80 @@ namespace PushSharp.Apple
         X509Certificate2 certificate;
         int id = 0;
         HttpTwo.Http2Client http2;
+        Timer keepAliveTimer;
+        TimeSpan keepAliveStartTimeSpan;
+        TimeSpan currentKeepAlivePeriod;
 
         private readonly object _syncObj = new object();
 
-        public async Task Send (ApnsHttp2Notification notification)
+
+        public async Task Send(ApnsHttp2Notification notification)
         {
-            var url = string.Format ("https://{0}:{1}/3/device/{2}", 
+            var url = string.Format("https://{0}:{1}/3/device/{2}",
                           Configuration.Host,
                           Configuration.Port,
-                          notification.DeviceToken);            
-            var uri = new Uri (url);
+                          notification.DeviceToken);
+            var uri = new Uri(url);
 
-            var payload = notification.Payload.ToString ();
+            var payload = notification.Payload.ToString();
 
-            var data = Encoding.UTF8.GetBytes (payload);
+            var data = Encoding.UTF8.GetBytes(payload);
 
-            var headers = new NameValueCollection ();
-            headers.Add ("apns-id", notification.Uuid); // UUID
+            var headers = new NameValueCollection();
+            headers.Add("apns-id", notification.Uuid); // UUID
 
-            if (notification.Expiration.HasValue) {
-                var sinceEpoch = notification.Expiration.Value.ToUniversalTime () - new DateTime (1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            if (notification.Expiration.HasValue)
+            {
+                var sinceEpoch = notification.Expiration.Value.ToUniversalTime() - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
                 var secondsSinceEpoch = (long)sinceEpoch.TotalSeconds;
-                headers.Add ("apns-expiration", secondsSinceEpoch.ToString ()); //Epoch in seconds
+                headers.Add("apns-expiration", secondsSinceEpoch.ToString()); //Epoch in seconds
             }
 
             if (notification.Priority.HasValue)
-                headers.Add ("apns-priority", notification.Priority == ApnsPriority.Low ? "5" : "10"); // 5 or 10
+                headers.Add("apns-priority", notification.Priority == ApnsPriority.Low ? "5" : "10"); // 5 or 10
 
-            headers.Add ("content-length", data.Length.ToString ());
+            headers.Add("content-length", data.Length.ToString());
 
-            if (!string.IsNullOrEmpty (notification.Topic)) 
-                headers.Add ("apns-topic", notification.Topic); // string topic
+            if (!string.IsNullOrEmpty(notification.Topic))
+                headers.Add("apns-topic", notification.Topic); // string topic
 
             Http2Client.Http2Response response;
             lock (_syncObj)
             {
-                response = http2.Post (uri, headers, data).Result;
+                response = http2.Post(uri, headers, data).Result;
             }
 
-            if (response.Status == HttpStatusCode.OK) {
+            if (response.Status == HttpStatusCode.OK)
+            {
                 // Check for matching uuid's
-                var responseUuid = response.Headers ["apns-id"];
+                var responseUuid = response.Headers["apns-id"];
                 if (responseUuid != notification.Uuid)
-                    throw new Exception ("Mismatched APNS-ID header values");
-            } else {
+                    throw new Exception("Mismatched APNS-ID header values");
+            }
+            else
+            {
                 // Try parsing json body
-                var json = new JObject ();
+                var json = new JObject();
 
-                if (response.Body != null && response.Body.Length > 0) {
-                    var body = Encoding.ASCII.GetString (response.Body);
-                    json = JObject.Parse (body);
+                if (response.Body != null && response.Body.Length > 0)
+                {
+                    var body = Encoding.ASCII.GetString(response.Body);
+                    json = JObject.Parse(body);
                 }
 
-                if (response.Status == HttpStatusCode.Gone) {
+                if (response.Status == HttpStatusCode.Gone)
+                {
 
                     var timestamp = DateTime.UtcNow;
-                    if (json != null && json["timestamp"] != null) {
-                        var sinceEpoch = json.Value<long> ("timestamp");
-                        timestamp = new DateTime (1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).AddSeconds (sinceEpoch);
+                    if (json != null && json["timestamp"] != null)
+                    {
+                        var sinceEpoch = json.Value<long>("timestamp");
+                        timestamp = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).AddSeconds(sinceEpoch);
                     }
 
                     // Expired
-                    throw new PushSharp.Core.DeviceSubscriptonExpiredException(notification) {
+                    throw new PushSharp.Core.DeviceSubscriptonExpiredException(notification)
+                    {
                         OldSubscriptionId = notification.DeviceToken,
                         NewSubscriptionId = null,
                         ExpiredAt = timestamp
@@ -130,12 +157,45 @@ namespace PushSharp.Apple
                 }
 
                 // Get the reason
-                var reasonStr = json.Value<string> ("reason");
+                var reasonStr = json.Value<string>("reason");
 
-                var reason = (ApnsHttp2FailureReason)Enum.Parse (typeof (ApnsHttp2FailureReason), reasonStr, true);
+                var reason = (ApnsHttp2FailureReason)Enum.Parse(typeof(ApnsHttp2FailureReason), reasonStr, true);
 
-                throw new ApnsHttp2NotificationException (reason, notification);
+                throw new ApnsHttp2NotificationException(reason, notification);
             }
+        }
+
+        private bool Ping()
+        {
+            // Stop and dispose timer
+            if (!Configuration.TryKeepingConnectionAlive)
+            {
+                Log.Info("TryKeepingConnectionAlive is FALSE -> exiting & disposing");
+
+                keepAliveTimer.Dispose();
+                return false;
+            }
+
+            Log.Debug("Starting ping execution");
+            var data = Encoding.UTF8.GetBytes("PINGPONG");
+
+            var cancelTokenSource = new CancellationTokenSource();
+            cancelTokenSource.CancelAfter(TimeSpan.FromSeconds(2));
+
+            var pong = http2.Ping(data, cancelTokenSource.Token).Result;
+            Log.Info($"Ping result={pong}");
+
+            // Change timer period
+            if (Configuration.KeepAlivePeriod != currentKeepAlivePeriod)
+            {
+                if (keepAliveTimer.Change(keepAliveStartTimeSpan, Configuration.KeepAlivePeriod))
+                {
+                    currentKeepAlivePeriod = Configuration.KeepAlivePeriod;
+                    Log.Info($"Kepp Alive Timer - Changed");
+                }
+            }
+
+            return pong;
         }
     }
 }

--- a/PushSharp.Apple/ApnsHttp2ServiceConnection.cs
+++ b/PushSharp.Apple/ApnsHttp2ServiceConnection.cs
@@ -22,8 +22,19 @@ namespace PushSharp.Apple
 
     public class ApnsHttp2ServiceBroker : ServiceBroker<ApnsHttp2Notification>
     {
+        public ApnsHttp2Configuration Configuration { get; private set; }
+
         public ApnsHttp2ServiceBroker (ApnsHttp2Configuration configuration) : base (new ApnsHttp2ServiceConnectionFactory (configuration))
         {
+            Configuration = configuration;
+        }
+
+        public new void Stop(bool immediately = false)
+        {
+            // MANDATORY -> needed to stop and dispose keep alive timer
+            Configuration.TryKeepingConnectionAlive = false;
+
+            base.Stop (immediately);
         }
     }
 

--- a/PushSharp.Apple/PushSharp.Apple.Http2.csproj
+++ b/PushSharp.Apple/PushSharp.Apple.Http2.csproj
@@ -37,7 +37,7 @@
       <HintPath>lib\HttpTwo.dll</HintPath>
     </Reference>
     <Reference Include="PushSharp.Core, Version=4.0.10.0, Culture=neutral, PublicKeyToken=cf74b75eab2c0170">
-      <HintPath>lib\ref\PushSharp.Core.dll</HintPath>
+      <HintPath>lib\PushSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="Newtonsoft.Json">


### PR DESCRIPTION
A keep alive is needed when we reuse the same service broker for hours or days. Without this, if we have an idle time >=1h notifications will not be sent.